### PR TITLE
cache attribute sets to improve performance

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from distutils.core import setup
 
 setup(name='MapperPy',
-      version='0.10',
+      version='0.11',
       description='Automatic object mapping tool',
       author='Lukasz Grech',
       author_email='mapperpy@gmail.com',


### PR DESCRIPTION
When mapping a lot (1000s or more) of objects, inspect.getmembers  overhead really starts to add up. This change caches the attributes on the first call to __get_common_instance_attributes