### PR TITLE
Add support for python 3

### DIFF
--- a/mapperpy/attributes_util.py
+++ b/mapperpy/attributes_util.py
@@ -4,7 +4,7 @@ import inspect
 def get_attributes(obj):
 
     if isinstance(obj, dict):
-        return obj.keys()
+        return list(obj.keys())
 
     attributes = inspect.getmembers(obj, lambda a: not(inspect.isroutine(a)))
     return [attr[0] for attr in attributes if not(attr[0].startswith('__') and attr[0].endswith('__'))]

--- a/mapperpy/object_mapper.py
+++ b/mapperpy/object_mapper.py
@@ -150,7 +150,7 @@ class ObjectMapper(object):
         mapping = {}
         rev_mapping = {}
 
-        for left, right in input_mapping.items():
+        for left, right in list(input_mapping.items()):
             if right is None:
                 # user requested to suppress implicit mapping for k
                 mapping[left] = rev_mapping[left] = None
@@ -164,7 +164,7 @@ class ObjectMapper(object):
         to_right_converters = {}
         to_left_converters = {}
 
-        for left_attr_name, converters_tuple in converters_dict.iteritems():
+        for left_attr_name, converters_tuple in converters_dict.items():
             if not isinstance(converters_tuple, tuple) or len(converters_tuple) != 2:
                 raise ValueError("Converters for {} should be provided in a 2-element tuple".format(left_attr_name))
 

--- a/mapperpy/test/conversions/test_custom_value_conversion.py
+++ b/mapperpy/test/conversions/test_custom_value_conversion.py
@@ -12,7 +12,7 @@ class CustomValueConversionTest(unittest.TestCase):
             OneWayMapper.for_target_class(TestClassSomePropertyEmptyInit1).target_value_converters(
                 {"some_property_02": 7}
             )
-        assert_that(context.exception.message).contains("some_property_02")
+        assert_that(context.exception.args[0]).contains("some_property_02")
 
     def test_map_for_single_converter(self):
         # given
@@ -70,21 +70,21 @@ class CustomValueConversionTest(unittest.TestCase):
             ObjectMapper.from_class(TestClassSomePropertyEmptyInit1, TestClassSomePropertyEmptyInit2).value_converters(
                 {"some_property_02": lambda val: 7})
 
-        assert_that(context.exception.message).contains("some_property_02")
+        assert_that(context.exception.args[0]).contains("some_property_02")
 
     def test_object_mapper_value_converters_when_converter_not_in_2_element_tuple_should_raise_exception(self):
         with self.assertRaises(ValueError) as context:
             ObjectMapper.from_class(TestClassSomePropertyEmptyInit1, TestClassSomePropertyEmptyInit2).value_converters(
                 {"some_property_02": (lambda val: 7,)})
 
-        assert_that(context.exception.message).contains("some_property_02")
+        assert_that(context.exception.args[0]).contains("some_property_02")
 
     def test_object_mapper_value_converters_when_converter_not_callable_should_raise_exception(self):
         with self.assertRaises(ValueError) as context:
             ObjectMapper.from_class(TestClassSomePropertyEmptyInit1, TestClassSomePropertyEmptyInit2).value_converters(
                 {"some_property_02": (lambda val: 7, "not_a_function")})
 
-        assert_that(context.exception.message).contains("some_property_02")
+        assert_that(context.exception.args[0]).contains("some_property_02")
 
     def test_object_mapper_map_with_value_converter_and_default_mapping(self):
         # given

--- a/mapperpy/test/conversions/test_datetime_conversion.py
+++ b/mapperpy/test/conversions/test_datetime_conversion.py
@@ -1,3 +1,4 @@
+import sys
 import unittest
 from assertpy import assert_that
 
@@ -7,6 +8,10 @@ from mapperpy import OneWayMapper, ObjectMapper
 from datetime import datetime
 
 __author__ = 'lgrech'
+
+
+if sys.version_info > (3, 0):
+    unicode = str
 
 
 class DateTimeConversionTest(unittest.TestCase):
@@ -50,7 +55,7 @@ class DateTimeConversionTest(unittest.TestCase):
             mapper.map(TestClassSomePropertyEmptyInit1(some_property_02="wrong_date_format"))
 
         # then
-        assert_that(context.exception.message).contains("wrong_date_format")
+        assert_that(context.exception.args[0]).contains("wrong_date_format")
 
     def test_map_from_string_to_datetime(self):
         # given

--- a/mapperpy/test/conversions/test_enum_conversion.py
+++ b/mapperpy/test/conversions/test_enum_conversion.py
@@ -1,3 +1,4 @@
+import sys
 import unittest
 from assertpy import assert_that
 from enum import Enum
@@ -7,6 +8,10 @@ from mapperpy.test.common_test_classes import *
 from mapperpy import ObjectMapper, OneWayMapper
 
 __author__ = 'lgrech'
+
+
+if sys.version_info > (3, 0):
+    unicode = str
 
 
 class EnumConversionTest(unittest.TestCase):

--- a/mapperpy/test/test_dict_mapping.py
+++ b/mapperpy/test/test_dict_mapping.py
@@ -221,8 +221,8 @@ class ObjectMapperDictMappingTest(unittest.TestCase):
             root_mapper.map(dict(some_property=TestClassSomePropertyEmptyInit1().__dict__))
 
         # then
-        assert_that(context.exception.message).contains("some_property")
-        assert_that(context.exception.message).contains("dict")
+        assert_that(context.exception.args[0]).contains("some_property")
+        assert_that(context.exception.args[0]).contains("dict")
 
     def test_map_explicit_when_ambiguous_nested_mapping_should_raise_exception(self):
         # given
@@ -237,9 +237,9 @@ class ObjectMapperDictMappingTest(unittest.TestCase):
             root_mapper.map(dict(some_property=dict()))
 
         # then
-        assert_that(context.exception.message).contains("some_property")
-        assert_that(context.exception.message).contains("mapped_property")
-        assert_that(context.exception.message).contains("dict")
+        assert_that(context.exception.args[0]).contains("some_property")
+        assert_that(context.exception.args[0]).contains("mapped_property")
+        assert_that(context.exception.args[0]).contains("dict")
 
     def test_map_with_multiple_nested_mappings_when_no_matching_mapper_for_target_type_should_raise_exception(self):
         # given
@@ -256,9 +256,9 @@ class ObjectMapperDictMappingTest(unittest.TestCase):
             root_mapper.map(dict(some_property=dict(some_property_02="nested_value_02")))
 
         # then
-        assert_that(context.exception.message).contains("some_property")
-        assert_that(context.exception.message).contains("dict")
-        assert_that(context.exception.message).contains("TestClassMappedPropertyEmptyInit")
+        assert_that(context.exception.args[0]).contains("some_property")
+        assert_that(context.exception.args[0]).contains("dict")
+        assert_that(context.exception.args[0]).contains("TestClassMappedPropertyEmptyInit")
 
     def test_map_with_multiple_nested_mappings_for_one_attribute_when_target_type_known(self):
         # given

--- a/mapperpy/test/test_object_mapper.py
+++ b/mapperpy/test/test_object_mapper.py
@@ -22,7 +22,7 @@ class ObjectMapperTest(unittest.TestCase):
             ObjectMapper.from_class(TestEmptyClass1, TestEmptyClass2).map(TestOtherClass())
             self.fail("Should raise ValueError")
         except ValueError as er:
-            assert_that(er.message).contains(TestOtherClass.__name__)
+            assert_that(er.args[0]).contains(TestOtherClass.__name__)
 
     def test_map_one_explicit_property(self):
         # given
@@ -54,7 +54,7 @@ class ObjectMapperTest(unittest.TestCase):
             self.fail("Should raise AttributeError")
         except AttributeError as er:
             # then
-            assert_that(er.message).contains("unknown")
+            assert_that(er.args[0]).contains("unknown")
 
         # given
         mapper = ObjectMapper.from_class(TestClassSomeProperty1, TestClassMappedProperty).custom_mappings(
@@ -66,7 +66,7 @@ class ObjectMapperTest(unittest.TestCase):
             self.fail("Should raise AttributeError")
         except AttributeError as er:
             # then
-            assert_that(er.message).contains("unknown")
+            assert_that(er.args[0]).contains("unknown")
 
     def test_map_multiple_explicit_properties(self):
         # given
@@ -211,8 +211,8 @@ class ObjectMapperTest(unittest.TestCase):
             root_mapper.nested_mapper(object())
 
         # then
-        assert_that(context.exception.message).contains(ObjectMapper.__name__)
-        assert_that(context.exception.message).contains("object")
+        assert_that(context.exception.args[0]).contains(ObjectMapper.__name__)
+        assert_that(context.exception.args[0]).contains("object")
 
     def test_nested_mapper_when_the_same_mapper_added_should_raise_exception(self):
         # given
@@ -226,8 +226,8 @@ class ObjectMapperTest(unittest.TestCase):
                 ObjectMapper.from_class(TestClassSomePropertyEmptyInit1, TestClassSomePropertyEmptyInit2))
 
         # then
-        assert_that(context.exception.message).contains(TestClassSomePropertyEmptyInit1.__name__)
-        assert_that(context.exception.message).contains(TestClassSomePropertyEmptyInit2.__name__)
+        assert_that(context.exception.args[0]).contains(TestClassSomePropertyEmptyInit1.__name__)
+        assert_that(context.exception.args[0]).contains(TestClassSomePropertyEmptyInit2.__name__)
 
     def test_map_with_nested_explicit_mapper(self):
         # given
@@ -297,8 +297,8 @@ class ObjectMapperTest(unittest.TestCase):
             root_mapper.map(TestClassSomeProperty1(some_property=TestClassSomePropertyEmptyInit1()))
 
         # then
-        assert_that(context.exception.message).contains("some_property")
-        assert_that(context.exception.message).contains("TestClassSomePropertyEmptyInit1")
+        assert_that(context.exception.args[0]).contains("some_property")
+        assert_that(context.exception.args[0]).contains("TestClassSomePropertyEmptyInit1")
 
     def test_map_explicit_when_ambiguous_nested_mapping_should_raise_exception(self):
         # given
@@ -314,9 +314,9 @@ class ObjectMapperTest(unittest.TestCase):
             root_mapper.map(TestClassSomeProperty1(some_property=TestClassSomePropertyEmptyInit1()))
 
         # then
-        assert_that(context.exception.message).contains("some_property")
-        assert_that(context.exception.message).contains("mapped_property")
-        assert_that(context.exception.message).contains("TestClassSomePropertyEmptyInit1")
+        assert_that(context.exception.args[0]).contains("some_property")
+        assert_that(context.exception.args[0]).contains("mapped_property")
+        assert_that(context.exception.args[0]).contains("TestClassSomePropertyEmptyInit1")
 
     def test_map_with_reversed_nested_mapper_should_not_use_nested_mapper(self):
         # given
@@ -424,7 +424,7 @@ class ObjectMapperTest(unittest.TestCase):
             mapper_strict.map(TestEmptyClass1())
             self.fail("Should raise AttributeError")
         except AttributeError as er:
-            assert_that(er.message).contains("non_existing_property")
+            assert_that(er.args[0]).contains("non_existing_property")
 
     def test_map_attr_name_for_empty_classes_should_raise_exception(self):
         # given
@@ -435,7 +435,7 @@ class ObjectMapperTest(unittest.TestCase):
             mapper.map_attr_name("unmapped_property")
 
         # then
-        assert_that(context.exception.message).contains("unmapped_property")
+        assert_that(context.exception.args[0]).contains("unmapped_property")
 
     def test_map_attr_name_for_unmapped_explicit_property_should_raise_exception(self):
         # given
@@ -447,7 +447,7 @@ class ObjectMapperTest(unittest.TestCase):
             mapper.map_attr_name("unmapped_property")
 
         # then
-        assert_that(context.exception.message).contains("unmapped_property")
+        assert_that(context.exception.args[0]).contains("unmapped_property")
 
     def test_map_attr_name_for_explicit_mapping(self):
         # given
@@ -474,14 +474,14 @@ class ObjectMapperTest(unittest.TestCase):
             mapper.map_attr_name("unmapped_property1")
 
         # then
-        assert_that(context.exception.message).contains("unmapped_property1")
+        assert_that(context.exception.args[0]).contains("unmapped_property1")
 
         # when
         with self.assertRaises(ValueError) as context:
             mapper.map_attr_name("unmapped_property2")
 
         # then
-        assert_that(context.exception.message).contains("unmapped_property2")
+        assert_that(context.exception.args[0]).contains("unmapped_property2")
 
     def test_map_attr_value_when_attr_name_unknown_should_raise_exception(self):
         # when
@@ -490,7 +490,7 @@ class ObjectMapperTest(unittest.TestCase):
                 map_attr_value("unknown_property", "some_value", MappingDirection.left_to_right)
 
         # then
-        assert_that(context.exception.message).contains("unknown_property")
+        assert_that(context.exception.args[0]).contains("unknown_property")
 
     def test_map_attr_value_when_attr_name_unknown_should_raise_exception_rev(self):
         # when
@@ -499,7 +499,7 @@ class ObjectMapperTest(unittest.TestCase):
                 map_attr_value("unknown_property", "some_value", MappingDirection.right_to_left)
 
         # then
-        assert_that(context.exception.message).contains("unknown_property")
+        assert_that(context.exception.args[0]).contains("unknown_property")
 
     def test_map_attr_value_when_opposite_direction_should_raise_exception(self):
         # when
@@ -509,8 +509,8 @@ class ObjectMapperTest(unittest.TestCase):
                 map_attr_value("some_property_02", "some_value", MappingDirection.right_to_left)
 
         # then
-        assert_that(context.exception.message).contains("some_property_02")
-        assert_that(context.exception.message).contains("right_to_left")
+        assert_that(context.exception.args[0]).contains("some_property_02")
+        assert_that(context.exception.args[0]).contains("right_to_left")
 
     def test_map_attr_value_when_opposite_direction_should_raise_exception_rev(self):
         # when
@@ -520,8 +520,8 @@ class ObjectMapperTest(unittest.TestCase):
                 map_attr_value("mapped_property_02", "some_value", MappingDirection.left_to_right)
 
         # then
-        assert_that(context.exception.message).contains("mapped_property_02")
-        assert_that(context.exception.message).contains("left_to_right")
+        assert_that(context.exception.args[0]).contains("mapped_property_02")
+        assert_that(context.exception.args[0]).contains("left_to_right")
 
     def test_map_attr_value(self):
         # when
@@ -559,8 +559,8 @@ class ObjectMapperTest(unittest.TestCase):
                 map_attr_value("some_property_02", "some_value", target_class=TestClassSomePropertyEmptyInit1)
 
         # then
-        assert_that(context.exception.message).contains("some_property_02")
-        assert_that(context.exception.message).contains("TestClassSomePropertyEmptyInit1")
+        assert_that(context.exception.args[0]).contains("some_property_02")
+        assert_that(context.exception.args[0]).contains("TestClassSomePropertyEmptyInit1")
 
     def test_map_attr_value_when_opposite_direction_for_class_should_raise_exception_rev(self):
         # when
@@ -570,8 +570,8 @@ class ObjectMapperTest(unittest.TestCase):
                 map_attr_value("mapped_property_02", "some_value", target_class=TestClassMappedPropertyEmptyInit)
 
         # then
-        assert_that(context.exception.message).contains("mapped_property_02")
-        assert_that(context.exception.message).contains("TestClassMappedPropertyEmptyInit")
+        assert_that(context.exception.args[0]).contains("mapped_property_02")
+        assert_that(context.exception.args[0]).contains("TestClassMappedPropertyEmptyInit")
 
     def test_map_attr_value_for_target_class(self):
         # when

--- a/mapperpy/test/test_one_way_mapper.py
+++ b/mapperpy/test/test_one_way_mapper.py
@@ -1,6 +1,10 @@
+import sys
 import unittest
 from assertpy import assert_that
-from mock import Mock
+if sys.version_info > (3, 0):
+    from unittest.mock import Mock
+else:
+    from mock import Mock
 
 from mapperpy.attributes_util import AttributesCache
 from mapperpy.test.common_test_classes import *
@@ -38,7 +42,7 @@ class OneWayMapperTest(unittest.TestCase):
             mapper.map(TestClassSomeProperty1(some_property="some_value"))
 
         # then
-        assert_that(context.exception.message).contains("unknown")
+        assert_that(context.exception.args[0]).contains("unknown")
 
     def test_map_multiple_explicit_properties(self):
         # given
@@ -137,8 +141,8 @@ class OneWayMapperTest(unittest.TestCase):
             root_mapper.nested_mapper(object(), TestClassSomeProperty1)
 
         # then
-        assert_that(context.exception.message).contains(OneWayMapper.__name__)
-        assert_that(context.exception.message).contains("object")
+        assert_that(context.exception.args[0]).contains(OneWayMapper.__name__)
+        assert_that(context.exception.args[0]).contains("object")
 
     def test_nested_mapper_when_the_same_mapper_added_should_raise_exception(self):
         # given
@@ -154,8 +158,8 @@ class OneWayMapperTest(unittest.TestCase):
                 TestClassSomePropertyEmptyInit1)
 
         # then
-        assert_that(context.exception.message).contains(TestClassSomePropertyEmptyInit1.__name__)
-        assert_that(context.exception.message).contains(TestClassSomePropertyEmptyInit2.__name__)
+        assert_that(context.exception.args[0]).contains(TestClassSomePropertyEmptyInit1.__name__)
+        assert_that(context.exception.args[0]).contains(TestClassSomePropertyEmptyInit2.__name__)
 
     def test_map_with_nested_explicit_mapper(self):
         # given
@@ -201,8 +205,8 @@ class OneWayMapperTest(unittest.TestCase):
             root_mapper.map(TestClassSomeProperty1(some_property=TestClassSomePropertyEmptyInit1()))
 
         # then
-        assert_that(context.exception.message).contains("some_property")
-        assert_that(context.exception.message).contains("TestClassSomePropertyEmptyInit1")
+        assert_that(context.exception.args[0]).contains("some_property")
+        assert_that(context.exception.args[0]).contains("TestClassSomePropertyEmptyInit1")
 
     def test_map_explicit_when_ambiguous_nested_mapping_should_raise_exception(self):
         # given
@@ -218,9 +222,9 @@ class OneWayMapperTest(unittest.TestCase):
             root_mapper.map(TestClassSomeProperty1(some_property=TestClassSomePropertyEmptyInit1()))
 
         # then
-        assert_that(context.exception.message).contains("some_property")
-        assert_that(context.exception.message).contains("mapped_property")
-        assert_that(context.exception.message).contains("TestClassSomePropertyEmptyInit1")
+        assert_that(context.exception.args[0]).contains("some_property")
+        assert_that(context.exception.args[0]).contains("mapped_property")
+        assert_that(context.exception.args[0]).contains("TestClassSomePropertyEmptyInit1")
 
     def test_map_with_multiple_nested_mappings_when_no_matching_mapper_for_target_type_should_raise_exception(self):
         # given
@@ -237,9 +241,9 @@ class OneWayMapperTest(unittest.TestCase):
                 some_property=TestClassSomePropertyEmptyInit1(some_property_02="nested_value_02")))
 
         # then
-        assert_that(context.exception.message).contains("some_property")
-        assert_that(context.exception.message).contains("TestClassSomePropertyEmptyInit1")
-        assert_that(context.exception.message).contains("TestClassMappedPropertyEmptyInit")
+        assert_that(context.exception.args[0]).contains("some_property")
+        assert_that(context.exception.args[0]).contains("TestClassSomePropertyEmptyInit1")
+        assert_that(context.exception.args[0]).contains("TestClassMappedPropertyEmptyInit")
 
     def test_map_with_multiple_nested_mappings_for_one_attribute_when_target_type_known(self):
         # given
@@ -297,7 +301,7 @@ class OneWayMapperTest(unittest.TestCase):
             OneWayMapper.for_target_prototype(TestClassSomePropertyEmptyInit1()).target_initializers(
                 {"some_property_02": 7}
             )
-        assert_that(context.exception.message).contains("some_property_02")
+        assert_that(context.exception.args[0]).contains("some_property_02")
 
     def test_map_with_custom_target_initializers(self):
         # given
@@ -335,7 +339,7 @@ class OneWayMapperTest(unittest.TestCase):
             mapper_strict.map(TestEmptyClass1())
 
         # then
-        assert_that(context.exception.message).contains("non_existing_property")
+        assert_that(context.exception.args[0]).contains("non_existing_property")
 
     def test_map_attr_name_for_empty_classes_should_raise_exception(self):
         # given
@@ -346,7 +350,7 @@ class OneWayMapperTest(unittest.TestCase):
             mapper.map_attr_name("unmapped_property")
 
         # then
-        assert_that(context.exception.message).contains("unmapped_property")
+        assert_that(context.exception.args[0]).contains("unmapped_property")
 
     def test_map_attr_name_for_unmapped_explicit_property_should_raise_exception(self):
         # given
@@ -358,7 +362,7 @@ class OneWayMapperTest(unittest.TestCase):
             mapper.map_attr_name("unmapped_property")
 
         # then
-        assert_that(context.exception.message).contains("unmapped_property")
+        assert_that(context.exception.args[0]).contains("unmapped_property")
 
     def test_map_attr_name_for_opposite_way_should_raise_exception(self):
         # given
@@ -370,7 +374,7 @@ class OneWayMapperTest(unittest.TestCase):
             mapper.map_attr_name("mapped_property")
 
         # then
-        assert_that(context.exception.message).contains("mapped_property")
+        assert_that(context.exception.args[0]).contains("mapped_property")
 
     def test_map_attr_name_for_explicit_mapping(self):
         # given
@@ -394,7 +398,7 @@ class OneWayMapperTest(unittest.TestCase):
             mapper.map_attr_name("unmapped_property1")
 
         # then
-        assert_that(context.exception.message).contains("unmapped_property1")
+        assert_that(context.exception.args[0]).contains("unmapped_property1")
 
     def test_for_target_class_when_object_passed_should_raise_exception(self):
         # when
@@ -402,7 +406,7 @@ class OneWayMapperTest(unittest.TestCase):
             OneWayMapper.for_target_class(object())
 
         # then
-        assert_that(context.exception.message).contains("object")
+        assert_that(context.exception.args[0]).contains("object")
 
     def test_for_target_class(self):
         assert_that(OneWayMapper.for_target_class(object)).is_not_none()
@@ -413,7 +417,7 @@ class OneWayMapperTest(unittest.TestCase):
             OneWayMapper.for_target_prototype(object)
 
         # then
-        assert_that(context.exception.message).contains("object")
+        assert_that(context.exception.args[0]).contains("object")
 
     def test_for_target_prototype(self):
         assert_that(OneWayMapper.for_target_prototype(object())).is_not_none()
@@ -425,7 +429,7 @@ class OneWayMapperTest(unittest.TestCase):
             OneWayMapper.for_target_class(TestClassSomePropertyEmptyInit1).map_attr_value("unknown_attr", "some_value")
 
         # then
-        assert_that(context.exception.message).contains("unknown_attr")
+        assert_that(context.exception.args[0]).contains("unknown_attr")
 
     def test_map_attr_value_for_none_attr_name_should_raise_exception(self):
 
@@ -434,7 +438,7 @@ class OneWayMapperTest(unittest.TestCase):
             OneWayMapper.for_target_class(TestClassSomePropertyEmptyInit1).map_attr_value(None, "some_value")
 
         # then
-        assert_that(context.exception.message).contains("None")
+        assert_that(context.exception.args[0]).contains("None")
 
     def test_map_attr_value_for_none_value(self):
         # given

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from distutils.core import setup
 
 setup(name='MapperPy',
-      version='0.11.1',
+      version='0.11.1py34',
       description='Automatic object mapping tool',
       author='Lukasz Grech',
       author_email='mapperpy@gmail.com',


### PR DESCRIPTION
Hi,

Found this lib quite useful for translating between SQLAlchemy model instances and Protobuf messages (gRPC). And I've made some changes for python3 support. Test cases are passed with both python2.7 and python3.4.

Please feel free to take it and / or comment for changes. 